### PR TITLE
Fixed bug in which closing group left orphan tabs

### DIFF
--- a/TabGroupBar/chrome/content/tabgroupbar.js
+++ b/TabGroupBar/chrome/content/tabgroupbar.js
@@ -269,7 +269,6 @@ objTabGroupBar.addGroupTab = function(groupItem) {
     tab.setAttribute("context", "TabGroupBar-TabContextMenu");
     tab.value = groupItem.id;
     
-    
     //tab.setAttribute("oncommand", "objTabGroupBar.switchGroupTo(event.target.value);");
     //tab.addEventListener("command", function(event) {objTabGroupBar.switchGroupTo(event.target.value);});
     //tab.setAttribute("ondblclick", "objTabGroupBar.createRenameGroupTextBox(event.target);");
@@ -382,6 +381,15 @@ objTabGroupBar.closeGroup = function(groupId){
     }
     //group.getChildren().forEach(function(tab){tab.close();});
     group.close({immediately: true});
+    
+    // shift all tabs to our right down one in sort order
+    for (key in this.groupSortOrder) {
+    	if (this.groupSortOrder[key] > this.groupSortOrder[groupId]) {
+    		this.groupSortOrder[key] -= 1
+    	}
+    }
+    delete this.groupSortOrder[groupId]
+    this.saveSortOrder()
 };
 
 objTabGroupBar.createNewGroup = function(){
@@ -391,6 +399,10 @@ objTabGroupBar.createNewGroup = function(){
         var blankTab = objTabGroupBar.window.getBrowser().addTab("about:blank");
         GroupItems.moveTabToGroupItem(blankTab, newGroup.id);
         objTabGroupBar.addGroupTab(newGroup);
+        
+        // sort this tab at the right
+        objTabGroupBar.groupSortOrder[newGroup.id] = Object.keys(objTabGroupBar.groupSortOrder).length+1
+    	objTabGroupBar.saveSortOrder()
     });
 };
 

--- a/TabGroupBar/chrome/content/tabgroupbar.js
+++ b/TabGroupBar/chrome/content/tabgroupbar.js
@@ -424,6 +424,38 @@ objTabGroupBar.renameGroupContextAction = function(event){
     this.createRenameGroupTextBox(event.target.parentNode.triggerNode);
 };
 
+objTabGroupBar.bookmarkGroupContextAction = function(event){
+    var tab = this.getPopupSourceElement(event);
+    var groupId = parseInt(tab.value);
+    var group = this.tabView.getContentWindow().GroupItems.groupItem(groupId)
+	this.bookmarkGroup(group)    
+};
+
+objTabGroupBar.bookmarkGroup = function(group) {
+  var folderName=window.prompt("Name of folder to put bookmarks in", group.getTitle());
+  if(folderName){
+    this.bookmarkGroupCore(group, folderName);
+  }
+};
+
+objTabGroupBar.bookmarkGroupCore = function(group, folderName) {
+  var places = Cc["@mozilla.org/browser/nav-bookmarks-service;1"].getService(Ci.nsINavBookmarksService);
+  if(!folderName){
+    folderName = group.getTitle();
+  }
+  
+  parentFolder = places.bookmarksMenuFolder;
+  
+  var newFolderId = places.createFolder(parentFolder, folderName, places.DEFAULT_INDEX);
+  var tabs = group.getChildren()
+  for(let ix=0; ix<tabs.length; ix++) {
+  	var tab = tabs[ix] 
+    var uri = tab.tab.linkedBrowser.currentURI;
+    var title=tab.tab.label;
+    places.insertBookmark(newFolderId, uri, places.DEFAULT_INDEX, title);
+  }
+};
+
 objTabGroupBar.onDbClickTab = function(event){
     this.createRenameGroupTextBox(event.target);
 };

--- a/TabGroupBar/chrome/content/tabgroupbar.js
+++ b/TabGroupBar/chrome/content/tabgroupbar.js
@@ -306,7 +306,10 @@ objTabGroupBar.onCloseGroupContextMenuAction  =  function(event){
 
 objTabGroupBar.closeGroup = function(groupId){
     var group = this.tabView.getContentWindow().GroupItems.groupItem(groupId);
-    group.getChildren().forEach(function(tab){tab.close();});
+    while (group.getChildren().length > 0) {
+    	group.getChildren()[0].close()
+    }
+    //group.getChildren().forEach(function(tab){tab.close();});
     group.close({immediately: true});
 };
 

--- a/TabGroupBar/chrome/content/tabgroupbar.js
+++ b/TabGroupBar/chrome/content/tabgroupbar.js
@@ -27,9 +27,8 @@ objTabGroupBar.init = function(window){
 
 	// doing this early apparently makes group tabs load BEFORE the active page loads
     this.tabView._initFrame()
-
+    
     this.refreshInfo();
-
 
     this.addGlobalEventListeners();	
     this.addTabContextMenuItems();
@@ -616,7 +615,7 @@ objTabGroupBar.toggleBar = function(){
 
 
 /////////////////// Initialize the extension on window load ///////////////////////////
-window.addEventListener("load",
+window.addEventListener("SSWindowStateReady",
     function(e)
     {
         objTabGroupBar.init(window);

--- a/TabGroupBar/chrome/content/tabgroupbar.js
+++ b/TabGroupBar/chrome/content/tabgroupbar.js
@@ -25,6 +25,8 @@ objTabGroupBar.init = function(window){
     this.tabView = this.getTabView();
     this.window = window;
 
+	// doing this early apparently makes group tabs load BEFORE the active page loads
+    this.tabView._initFrame()
 
     this.refreshInfo();
 
@@ -47,7 +49,7 @@ objTabGroupBar.observe = function(subject, topic, data){
 
 objTabGroupBar.refreshInfo = function(){
     let console = (Cu.import("resource://gre/modules/devtools/Console.jsm", {})).console;
-    console.log("Preference change");
+    //console.log("Preference change");
     var preferences = Components.classes["@mozilla.org/preferences-service;1"]
         .getService(Components.interfaces.nsIPrefService).getBranch("extensions.tabgroupbar.");
    	 

--- a/TabGroupBar/chrome/content/tabgroupbar.js
+++ b/TabGroupBar/chrome/content/tabgroupbar.js
@@ -340,7 +340,7 @@ objTabGroupBar.switchGroupTo = function(groupId){
     else
     {
         tab = this.window.getBrowser().addTab("about:blank");
-        GroupItems.moveTabToGroupItem(tab, groupToActivate.id);
+        groupItems.moveTabToGroupItem(tab, groupToActivate.id);
     }
     this.ignoreNextEvent = true; //tells the extension to ignore the TabSelected event caused by switching groups
     this.window.gBrowser.selectedTab = tabItem.tab;

--- a/TabGroupBar/chrome/content/tabgroupbar.xul
+++ b/TabGroupBar/chrome/content/tabgroupbar.xul
@@ -53,8 +53,10 @@
         <arrowscrollbox orient="horizontal">
           <tabs id="TabGroupBar-TabBox-Tabs" flex="1"/>
         </arrowscrollbox>
-
       </tabbox>
+      <toolbarbutton class="TabGroup move left" oncommand="objTabGroupBar.moveTabLeft()" label="&#x2190;"/>
+      <toolbarbutton class="TabGroup move right" oncommand="objTabGroupBar.moveTabRight()" label="&#x2192;"/>
+
     </toolbar>
   </toolbox>
 </overlay>

--- a/TabGroupBar/chrome/content/tabgroupbar.xul
+++ b/TabGroupBar/chrome/content/tabgroupbar.xul
@@ -25,6 +25,8 @@
                       oncommand="objTabGroupBar.onCloseGroupContextMenuAction(event)"/>
       <menuitem id="TabGroupBar-TabContextMenu-RenameGroup" 	label="Rename Group"
                       oncommand="objTabGroupBar.renameGroupContextAction(event)"/>
+      <menuitem id="TabGroupBar-TabContextMenu-BookmarkGroup" 	label="Bookmark Group"
+                      oncommand="objTabGroupBar.bookmarkGroupContextAction(event)"/>
       <menu 	  id="TabGroupBar-TabContextMenu-TabMenu"		label="Tabs">
             <menupopup   id="TabGroupBar-TabContextMenu-TabMenu-Popup" 
             onpopupshowing="objTabGroupBar.onTabListPopupShowing(event);" 


### PR DESCRIPTION
The bug was caused by closing the tabs in the group while iterating over the list of tabs.  Closing a tab removes it from the list, so we were changing the list while iterating over it.  This caused some tabs to be skipped in iteration and not closed, and these were left as orphan tabs.
